### PR TITLE
【Fixed】`rails g`コマンドの際に入らないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,11 @@ module FriendNote
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1 

config/application.rbを編集して、generateでassetsとhelperを作成しないように設定